### PR TITLE
Update mimemagic to 0.3.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,9 @@ GEM
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)


### PR DESCRIPTION
Hey there 👋🏼 

An installation on a new machine causes bundler to fail because mimemagic 0.3.5 cannot be found:

```
scheduled_tweets on master via v3.0.0 via v15.14.0
❯ bundle
Fetching gem metadata from https://rubygems.org/..........
Your bundle is locked to mimemagic (0.3.5), but that version could not be found in any of the sources listed in your Gemfile. If you haven't changed sources, that means the author of mimemagic
(0.3.5) has removed it. You'll need to update your bundle to a version other than mimemagic (0.3.5) that hasn't been removed in order to install.
```

This PR bumps mimemagic to 0.3.10 in order to successfully run `bundle install`